### PR TITLE
Implement master and tests for it

### DIFF
--- a/common/src/main/scala/Comparable.scala
+++ b/common/src/main/scala/Comparable.scala
@@ -1,4 +1,3 @@
-
 package common
 
 import java.lang.IllegalArgumentException

--- a/common/src/main/scala/Key.scala
+++ b/common/src/main/scala/Key.scala
@@ -1,4 +1,3 @@
-
 package common
 
 object Key{

--- a/common/src/main/scala/common.scala
+++ b/common/src/main/scala/common.scala
@@ -1,4 +1,3 @@
-
 import java.io._
 
 package object common {

--- a/common/src/main/scala/futureExt.scala
+++ b/common/src/main/scala/futureExt.scala
@@ -1,0 +1,20 @@
+package common
+
+import scala.concurrent.{Future, Promise, ExecutionContext}
+
+object FutureExt {
+  implicit private val ec = ExecutionContext.global
+
+  implicit class FutureCompanionOps(val f: Future.type) extends AnyVal {
+
+    def always[T](value: T): Future[T] = Promise[T].success(value).future
+
+    def never[T]: Future[T] = Promise[T].future
+
+    def all[T](fs: List[Future[T]]): Future[List[T]] =
+      fs match {
+        case Nil => Future { Nil }
+        case head::tail => head.zip(all(tail)).flatMap { case (head, tail) => Future { head::tail } }
+      }
+  }
+}

--- a/master/src/main/scala/entrypoint.scala
+++ b/master/src/main/scala/entrypoint.scala
@@ -1,3 +1,4 @@
+package master
 import master.server.DistSortServerImpl
 
 object Entrypoint {

--- a/master/src/main/scala/entrypoint.scala
+++ b/master/src/main/scala/entrypoint.scala
@@ -6,8 +6,9 @@ object Entrypoint {
       case Some(n) => n.toInt
       case None => throw new Exception("Provide # of workers")
     }
+    val overridePort = args.lift(1).map(_.toInt)
     require(numWorkers > 0)
     // This function blocks the main thread until the server is shut down.
-    DistSortServerImpl.serveRPC(numWorkers)
+    DistSortServerImpl.serveRPC(numWorkers, overridePort)
   }
 }

--- a/master/src/main/scala/entrypoint.scala
+++ b/master/src/main/scala/entrypoint.scala
@@ -1,33 +1,13 @@
-import java.net.ServerSocket
-import network.utils.ReadWriteSocket
+import master.server.DistSortServerImpl
 
 object Entrypoint {
-  def handle_request(rwSocket: ReadWriteSocket) = {
-    val message_from_worker = rwSocket.read_string(100).trim
-    require(message_from_worker == "message from worker")
-    val message = "message from master"
-    rwSocket.write_string(message)
-  }
-
   def main(args: Array[String]) = {
-    val num_workers = args.lift(0) match {
+    val numWorkers = args.lift(0) match {
       case Some(n) => n.toInt
       case None => throw new Exception("Provide # of workers")
     }
-    val port = args.lift(1).getOrElse("44123").toInt
-    val socket = new ServerSocket(port)
-    val listen_address = s"${socket.getInetAddress.getHostAddress}:${socket.getLocalPort}"
-    println(listen_address)
-
-    val addresses_of_workers = for {i <- 0 until num_workers} yield {
-      val connection_to_client = socket.accept()
-      val client_address = s"${connection_to_client.getRemoteSocketAddress}".stripPrefix("/")
-      val rwSocket = new ReadWriteSocket(connection_to_client)
-      handle_request(rwSocket)
-      connection_to_client.close()
-      client_address
-    }
-    println(addresses_of_workers.mkString(", "))
-    socket.close()
+    require(numWorkers > 0)
+    // This function blocks the main thread until the server is shut down.
+    DistSortServerImpl.serveRPC(numWorkers)
   }
 }

--- a/master/src/main/scala/master.scala
+++ b/master/src/main/scala/master.scala
@@ -42,7 +42,7 @@ class Master(numWorkers: Int) {
     syncKeyRange
   }
 
-  // Executes only once.
+  // This is and should be executed only once.
   private def calculateKeyRange() = {
     val numSamples = syncNumSamples.take
     val samples = syncSamples.take
@@ -52,14 +52,14 @@ class Master(numWorkers: Int) {
     val sortedKeys = keys.sort
     assert(sortedKeys.isSorted)
 
+    val step = numSamples / numWorkers
     val keyRange = for {
-      i <- (0 until numWorkers).toList
-      step <- Some(numSamples / numWorkers)
-      index <- Some(i * step)
-    } yield sortedKeys(index).asBytes
+      i <- (0 until numWorkers by step).toList
+    } yield sortedKeys(i).asBytes
 
+    val minimumKey = Key(List.fill(10)(0.toByte)).asBytes
     val keyRangeResult = keyRange match {
-      case head::tail => List[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0).toArray :: tail
+      case head :: tail => minimumKey :: tail
       case Nil => Nil
     }
 

--- a/master/src/main/scala/master.scala
+++ b/master/src/main/scala/master.scala
@@ -1,17 +1,69 @@
 package master
 
-import scala.concurrent.{ExecutionContext, Future}
+import java.util.concurrent.CountDownLatch
+import scala.concurrent.{ExecutionContext, Future, SyncVar, Promise}
+import common.Key
 
-object Master {
+class Master(numWorkers: Int) {
+  type Bytes = Array[Byte]
   private implicit val ec = ExecutionContext.global
 
+  private val syncNumSamples = new SyncVar[Int]
+  private val syncSamples = new SyncVar[List[Bytes]]
+
+  private val remainingRequests = new SyncVar[Int]
+  remainingRequests.put(numWorkers)
+  private val calculationTrigger = Promise[Unit]
+  calculationTrigger.future.foreach(_ => calculateKeyRange())
+
+  private val syncKeyRange = new SyncVar[(List[Array[Byte]], List[String])]
+
+  private var workerIpAddressList: Option[List[String]] = None
+
+  def setWorkerIpAddressList(workerIpAddressList: List[String]) = {
+    assert(numWorkers == workerIpAddressList.length)
+    assert(workerIpAddressList.isEmpty)
+    this.workerIpAddressList = Some(workerIpAddressList)
+  }
+
   def divideKeyRange(
-    populationSize: Int,
     numSamples: Int,
-    samples: Iterable[Iterable[Byte]],
-    ): Future[(String, (List[Byte], List[Byte]))] = {
-    Future {("", (List(), List()))}
+    samples: List[Bytes],
+  ): SyncVar[(List[Bytes], List[String])] = {
+    for (sample <- samples) assert(sample.length == 10)
+    assert(samples.size == numSamples)
+
+    syncNumSamples.put(numSamples + syncNumSamples.get)
+    syncSamples.put(samples ++ syncSamples.get)
+    remainingRequests.take match {
+      case 1 => calculationTrigger.success(())
+      case n => remainingRequests.put(n - 1)
+    }
+    syncKeyRange
+  }
+
+  // Executes only once.
+  private def calculateKeyRange() = {
+    val numSamples = syncNumSamples.take
+    val samples = syncSamples.take
+    assert(numSamples == samples.size)
+    
+    val keys = samples.map(sample => Key(sample.toList))
+    val sortedKeys = keys.sort
+    assert(sortedKeys.isSorted)
+
+    val keyRange = for {
+      i <- (0 until numWorkers).toList
+      step <- Some(numSamples / numWorkers)
+      index <- Some(i * step)
+    } yield sortedKeys(index).asBytes
+
+    val keyRangeResult = keyRange match {
+      case head::tail => List[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0).toArray :: tail
+      case Nil => Nil
+    }
+
+    assert(workerIpAddressList.isDefined && workerIpAddressList.get.size == numWorkers)
+    syncKeyRange.put((keyRangeResult, workerIpAddressList.get))
   }
 }
-
-class Master {}

--- a/master/src/main/scala/master.scala
+++ b/master/src/main/scala/master.scala
@@ -1,22 +1,16 @@
 package master
 
-class Key(protected val key: Int) {
-  def <(that: Key): Boolean = key < that.key
-  def ==(that: Key): Boolean = key == that.key
-}
-
-object Key {
-  val MAX: Key = new Key(Int.MaxValue)
-  val MIN: Key = new Key(Int.MinValue)
-}
+import scala.concurrent.{ExecutionContext, Future}
 
 object Master {
+  private implicit val ec = ExecutionContext.global
+
   def divideKeyRange(
     populationSize: Int,
     numSamples: Int,
     samples: Iterable[Iterable[Byte]],
-    ): (String, (List[Byte], List[Byte])) = {
-    ("", (List(), List()))
+    ): Future[(String, (List[Byte], List[Byte]))] = {
+    Future {("", (List(), List()))}
   }
 }
 

--- a/master/src/main/scala/master.scala
+++ b/master/src/main/scala/master.scala
@@ -1,0 +1,23 @@
+package master
+
+class Key(protected val key: Int) {
+  def <(that: Key): Boolean = key < that.key
+  def ==(that: Key): Boolean = key == that.key
+}
+
+object Key {
+  val MAX: Key = new Key(Int.MaxValue)
+  val MIN: Key = new Key(Int.MinValue)
+}
+
+object Master {
+  def divideKeyRange(
+    populationSize: Int,
+    numSamples: Int,
+    samples: Iterable[Iterable[Byte]],
+    ): (String, (List[Byte], List[Byte])) = {
+    ("", (List(), List()))
+  }
+}
+
+class Master {}

--- a/master/src/main/scala/server.scala
+++ b/master/src/main/scala/server.scala
@@ -1,0 +1,43 @@
+import network.distsort.server.DistSortServer
+import scala.concurrent.ExecutionContext
+import java.util.concurrent.CountDownLatch
+import scala.concurrent.{Promise, SyncVar}
+import master.Master
+
+class DistSortServerImpl(port: Int, numWorkers: Int, notifyShutdown: Promise[Unit]) extends DistSortServer(ExecutionContext.global) {
+  private val readyRequestLatch = new CountDownLatch(numWorkers)
+  private val keyRangeRequestLatch = new CountDownLatch(numWorkers)
+  private val partitionRequestLatch = new CountDownLatch(numWorkers)
+  private val shutdownLatch = new SyncVar[Int]
+  shutdownLatch.put(numWorkers)
+
+  def handleReadyRequest(workerName: String) = {
+    readyRequestLatch.countDown()
+    readyRequestLatch.await()
+  }
+
+  def handleKeyRangeRequest(
+    populationSize: Int,
+    numSamples: Int,
+    samples: Iterable[Iterable[Byte]],
+    ): (String, (List[Byte], List[Byte])) = {
+    val allKeyRanges = Master.divideKeyRange(populationSize, numSamples, samples)
+    keyRangeRequestLatch.countDown()
+    keyRangeRequestLatch.await()
+    allKeyRanges
+  }
+
+  def handlePartitionRequest() = {
+    partitionRequestLatch.countDown()
+    partitionRequestLatch.await()
+  }
+
+  def handleSortFinishRequest() = {
+    val count = shutdownLatch.take()
+    assert(count > 0)
+    count match {
+      case 1 => notifyShutdown.success(())
+      case n => shutdownLatch.put(n - 1)
+    }
+  }
+}

--- a/master/src/main/scala/server.scala
+++ b/master/src/main/scala/server.scala
@@ -1,4 +1,4 @@
-import network.distsort.server.DistSortServer
+import network.rpc.master.server.DistSortServer
 import scala.concurrent.ExecutionContext
 import java.util.concurrent.CountDownLatch
 import scala.concurrent.{Promise, SyncVar}

--- a/master/src/main/scala/server.scala
+++ b/master/src/main/scala/server.scala
@@ -26,9 +26,8 @@ object DistSortServerImpl {
   }
 }
 
-class DistSortServerImpl(port: Int, numWorkers: Int,
-  connectedWorkers: Promise[List[String]],
-) extends DistSortServer(ExecutionContext.global) {
+class DistSortServerImpl(port: Int, numWorkers: Int, connectedWorkers: Promise[List[String]])
+extends DistSortServer(port, ExecutionContext.global) {
   private val readyRequestLatch = new CountDownLatch(numWorkers)
   private val keyRangeRequestLatch = new CountDownLatch(numWorkers)
   private val partitionRequestLatch = new CountDownLatch(numWorkers)
@@ -37,7 +36,7 @@ class DistSortServerImpl(port: Int, numWorkers: Int,
   private val syncShutdown = new SyncVar[Int]
   syncShutdown.put(numWorkers)
 
-  def handleReadyRequest(workerName: String) = {
+  def handleReadyRequest(workerName: String, workerIpAddress: String) = {
     readyRequestLatch.countDown()
     readyRequestLatch.await()
   }

--- a/master/src/main/scala/server.scala
+++ b/master/src/main/scala/server.scala
@@ -1,11 +1,11 @@
 package master.server
 
 import network.rpc.master.server.DistSortServer
-import scala.concurrent.{ExecutionContext, Promise}
 import java.net.InetAddress
 import java.util.concurrent.CountDownLatch
-import scala.concurrent.{Promise, SyncVar, Future, Await}
+import scala.concurrent.{Promise, SyncVar, Future, Await, ExecutionContext, blocking}
 import scala.concurrent.duration.Duration
+import master.util.sync.SyncAccList
 import master.Master
 
 
@@ -30,18 +30,27 @@ object DistSortServerImpl {
 
 class DistSortServerImpl(port: Int, numWorkers: Int, connectedWorkers: Promise[List[String]])
 extends DistSortServer(port, ExecutionContext.global) {
+  implicit private val ec = ExecutionContext.global
+
   private val master = new Master(numWorkers)
+
   private val readyRequestLatch = new CountDownLatch(numWorkers)
   private val keyRangeRequestLatch = new CountDownLatch(numWorkers)
   private val partitionRequestLatch = new CountDownLatch(numWorkers)
-  private val syncConnectedWorkers = new SyncVar[List[String]]
-  syncConnectedWorkers.put(List())
-  private val syncShutdown = new SyncVar[Int]
-  syncShutdown.put(numWorkers)
+  private val shutdownLatch = new CountDownLatch(numWorkers)
+
+  private val syncConnectedWorkers = new SyncAccList[String](List())
+
+  private val triggerShutdown = Promise[Unit]
+  triggerShutdown.future.foreach{_ => Future { blocking {
+      Thread.sleep(3000)
+      this.stop()
+    }
+  }}
 
   def handleReadyRequest(workerName: String, workerIpAddress: String) = {
+    syncConnectedWorkers.accumulate(List(workerIpAddress))
     readyRequestLatch.countDown()
-    syncConnectedWorkers.put(workerIpAddress :: syncConnectedWorkers.take)
     readyRequestLatch.await()
     connectedWorkers.trySuccess(syncConnectedWorkers.get)
   }
@@ -62,11 +71,8 @@ extends DistSortServer(port, ExecutionContext.global) {
   }
 
   def handleSortFinishRequest() = {
-    val count = syncShutdown.take()
-    assert(count > 0)
-    count match {
-      case 1 => this.stop()
-      case n => syncShutdown.put(n - 1)
-    }
+    shutdownLatch.countDown()
+    shutdownLatch.await()
+    triggerShutdown.trySuccess(())
   }
 }

--- a/master/src/main/scala/server.scala
+++ b/master/src/main/scala/server.scala
@@ -10,19 +10,20 @@ import master.Master
 
 
 object DistSortServerImpl {
-  final val port = 55555
+  final val defaultPort = 55555
   implicit val ec = ExecutionContext.global
 
   private def printConnectedWorkers(workers: List[String]) = {
     println(workers.mkString(", "))
   }
   
-  def serveRPC(numWorkers: Int) = {
+  def serveRPC(numWorkers: Int, overridePort: Option[Int]) = {
     val connectedWorkers = Promise[List[String]]
+    val port = overridePort.getOrElse(this.defaultPort)
     val server = new DistSortServerImpl(port, numWorkers, connectedWorkers)
     server.start()
     val localIpAddress = InetAddress.getLocalHost.getHostAddress
-    println(localIpAddress)
+    println(s"$localIpAddress:$port")
     connectedWorkers.future.foreach(printConnectedWorkers)
     server.blockUntilShutdown()
   }

--- a/master/src/main/scala/server.scala
+++ b/master/src/main/scala/server.scala
@@ -1,15 +1,41 @@
+package master.server
+
 import network.rpc.master.server.DistSortServer
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Promise}
 import java.util.concurrent.CountDownLatch
-import scala.concurrent.{Promise, SyncVar}
+import scala.concurrent.{Promise, SyncVar, Future, Await}
+import scala.concurrent.duration.Duration
 import master.Master
 
-class DistSortServerImpl(port: Int, numWorkers: Int, notifyShutdown: Promise[Unit]) extends DistSortServer(ExecutionContext.global) {
+
+object DistSortServerImpl {
+  final val port = 55555
+  implicit val ec = ExecutionContext.global
+
+  private def printConnectedWorkers(workers: List[String]) = {
+    println(workers.mkString(", "))
+  }
+  
+  def serveRPC(numWorkers: Int) = {
+    val connectedWorkers = Promise[List[String]]
+    val server = new DistSortServerImpl(port, numWorkers, connectedWorkers)
+    server.start()
+    println(server.getListenAddress())
+    connectedWorkers.future.foreach(printConnectedWorkers)
+    server.blockUntilShutdown()
+  }
+}
+
+class DistSortServerImpl(port: Int, numWorkers: Int,
+  connectedWorkers: Promise[List[String]],
+) extends DistSortServer(ExecutionContext.global) {
   private val readyRequestLatch = new CountDownLatch(numWorkers)
   private val keyRangeRequestLatch = new CountDownLatch(numWorkers)
   private val partitionRequestLatch = new CountDownLatch(numWorkers)
-  private val shutdownLatch = new SyncVar[Int]
-  shutdownLatch.put(numWorkers)
+  private val syncConnectedWorkers = new SyncVar[List[String]]
+  syncConnectedWorkers.put(List())
+  private val syncShutdown = new SyncVar[Int]
+  syncShutdown.put(numWorkers)
 
   def handleReadyRequest(workerName: String) = {
     readyRequestLatch.countDown()
@@ -17,14 +43,14 @@ class DistSortServerImpl(port: Int, numWorkers: Int, notifyShutdown: Promise[Uni
   }
 
   def handleKeyRangeRequest(
-    populationSize: Int,
-    numSamples: Int,
-    samples: Iterable[Iterable[Byte]],
+      populationSize: Int,
+      numSamples: Int,
+      samples: Iterable[Iterable[Byte]],
     ): (String, (List[Byte], List[Byte])) = {
     val allKeyRanges = Master.divideKeyRange(populationSize, numSamples, samples)
     keyRangeRequestLatch.countDown()
     keyRangeRequestLatch.await()
-    allKeyRanges
+    Await.result(allKeyRanges, Duration.Inf)
   }
 
   def handlePartitionRequest() = {
@@ -33,11 +59,11 @@ class DistSortServerImpl(port: Int, numWorkers: Int, notifyShutdown: Promise[Uni
   }
 
   def handleSortFinishRequest() = {
-    val count = shutdownLatch.take()
+    val count = syncShutdown.take()
     assert(count > 0)
     count match {
-      case 1 => notifyShutdown.success(())
-      case n => shutdownLatch.put(n - 1)
+      case 1 => this.stop()
+      case n => syncShutdown.put(n - 1)
     }
   }
 }

--- a/master/src/main/scala/sync.scala
+++ b/master/src/main/scala/sync.scala
@@ -1,6 +1,7 @@
 package master.util.sync
 
 import scala.concurrent.SyncVar
+import java.util.logging.Logger
 
 abstract class SyncAcc[T](initialValue: T) extends SyncVar[T] {
   this.put(initialValue)
@@ -9,13 +10,23 @@ abstract class SyncAcc[T](initialValue: T) extends SyncVar[T] {
 }
 
 class SyncAccList[T](initialValue: List[T]) extends SyncAcc[List[T]](initialValue) {
+  private val logger = Logger.getLogger(classOf[SyncAccList[T]].getName)
   def accumulate(incoming: List[T]): Unit = {
-    this.put(this.take ++ incoming)
+    val taken = this.take
+    logger.finer(s"Value taken: $taken")
+    logger.finer(s"Accumulating value: $incoming")
+    this.put(taken ++ incoming)
+    logger.finer("Value put")
   }
 }
 
 class SyncAccInt(initialValue: Int) extends SyncAcc[Int](initialValue) {
+  private val logger = Logger.getLogger(classOf[SyncAccInt].getName)
   def accumulate(incoming: Int): Unit = {
-    this.put(this.take + incoming)
+    val taken = this.take
+    logger.finer(s"Value taken: $taken")
+    logger.finer(s"Accumulating value: $incoming")
+    this.put(taken + incoming)
+    logger.finer("Value put")
   }
 }

--- a/master/src/main/scala/sync.scala
+++ b/master/src/main/scala/sync.scala
@@ -1,0 +1,21 @@
+package master.util.sync
+
+import scala.concurrent.SyncVar
+
+abstract class SyncAcc[T](initialValue: T) extends SyncVar[T] {
+  this.put(initialValue)
+
+  def accumulate(newValue: T): Unit
+}
+
+class SyncAccList[T](initialValue: List[T]) extends SyncAcc[List[T]](initialValue) {
+  def accumulate(incoming: List[T]): Unit = {
+    this.put(this.take ++ incoming)
+  }
+}
+
+class SyncAccInt(initialValue: Int) extends SyncAcc[Int](initialValue) {
+  def accumulate(incoming: Int): Unit = {
+    this.put(this.take + incoming)
+  }
+}

--- a/master/src/test/scala/syncTest.scala
+++ b/master/src/test/scala/syncTest.scala
@@ -1,0 +1,51 @@
+import org.scalatest.funsuite.AnyFunSuite
+
+import master.util.sync.{SyncAccList, SyncAccInt}
+
+class SyncAccSuite extends AnyFunSuite {
+
+  test("SyncAccList[T] - mere merge") {
+    val syncAcc = new SyncAccList[Int](List(1, 2, 3))
+    val incoming = List(4, 5, 6)
+    val expected = List(1, 2, 3, 4, 5, 6)
+    syncAcc.accumulate(incoming)
+    val actual = syncAcc.take
+    assert(actual == expected)
+  }
+
+  test("SyncAccList[T] - merge with empty") {
+    val syncAcc = new SyncAccList[Int](List())
+    val incoming = List(4, 5, 6)
+    val expected = List(4, 5, 6)
+    syncAcc.accumulate(incoming)
+    val actual = syncAcc.take
+    assert(actual == expected)
+  }
+
+  test("SyncAccList[T] - accumulate with empty") {
+    val syncAcc = new SyncAccList[Int](List(1, 2, 3))
+    val incoming = List()
+    val expected = List(1, 2, 3)
+    syncAcc.accumulate(incoming)
+    val actual = syncAcc.take
+    assert(actual == expected)
+  }
+
+  test("SyncAccInt - mere merge") {
+    val syncAcc = new SyncAccInt(123)
+    val incoming = 456
+    val expected = 123 + 456
+    syncAcc.accumulate(incoming)
+    val actual = syncAcc.take
+    assert(actual == expected)
+  }
+
+  test("SyncAccInt - mere merge negative number") {
+    val syncAcc = new SyncAccInt(123)
+    val incoming = -456
+    val expected = 123 - 456
+    syncAcc.accumulate(incoming)
+    val actual = syncAcc.take
+    assert(actual == expected)
+  }
+}

--- a/network/src/main/scala/rpc/master/server.scala
+++ b/network/src/main/scala/rpc/master/server.scala
@@ -51,13 +51,18 @@ class DistSortServer(executionContext: ExecutionContext) { self =>
     }
   }
 
-  private def stop(): Unit = {
+  def getListenAddress(): String = {
+    val socket = server.getListenSockets().get(0)
+    socket.toString()
+  }
+
+  def stop(): Unit = {
     if (server != null) {
       server.shutdown()
     }
   }
 
-  private def blockUntilShutdown(): Unit = {
+  def blockUntilShutdown(): Unit = {
     if (server != null) {
       server.awaitTermination()
     }

--- a/network/src/main/scala/rpc/master/server.scala
+++ b/network/src/main/scala/rpc/master/server.scala
@@ -41,7 +41,7 @@ object DistSortServer {
 class DistSortServer(executionContext: ExecutionContext) { self =>
   private[this] var server: Server = null
 
-  private def start(): Unit = {
+  def start(): Unit = {
     server = ServerBuilder.forPort(DistSortServer.port).addService(DistsortMasterGrpc.bindService(new DistsortMasterImpl, executionContext)).build.start
     DistSortServer.logger.info("Server started, listening on " + DistSortServer.port)
     sys.addShutdownHook {

--- a/network/src/main/scala/rpc/master/server.scala
+++ b/network/src/main/scala/rpc/master/server.scala
@@ -63,7 +63,9 @@ abstract class DistSortServer(port: Int, executionContext: ExecutionContext) {
       samples: List[Array[Byte]],
     ): (List[Array[Byte]], List[String])
 
-  def handlePartitionRequest(): Unit
+  def handlePartitionCompleteRequest(): Unit
+    
+  def handleExchangeCompleteRequest(): Unit
 
   def handleSortFinishRequest(): Unit
 
@@ -88,21 +90,25 @@ abstract class DistSortServer(port: Int, executionContext: ExecutionContext) {
       val keyList = for (key <- keyList_) yield ByteString.copyFrom(key)
 
       val reply = KeyRangeReply(
-        keyList = List(),
-        workerIpList = List(),
+        keyList = keyList,
+        workerIpList = workerIpAddressList,
       )
       Future.successful(reply)
     }
 
-    override def exchangeComplete(request: ExchangeCompleteRequest): Future[ExchangeCompleteReply] = {
-      // Todo: implement this
-      val reply = ExchangeCompleteReply()
+    override def partitionComplete(request: PartitionCompleteRequest): Future[PartitionCompleteReply] = {
+      logger.info("Received PartitionCompleteRequest")
+
+      val _ = handlePartitionCompleteRequest()
+      val reply = PartitionCompleteReply()
       Future.successful(reply)
     }
 
-    override def partitionComplete(request: PartitionCompleteRequest): Future[PartitionCompleteReply] = {
-      // Todo: implement this
-      val reply = PartitionCompleteReply()
+    override def exchangeComplete(request: ExchangeCompleteRequest): Future[ExchangeCompleteReply] = {
+      logger.info("Received ExchangeCompleteRequest")
+
+      val _ = handleExchangeCompleteRequest()
+      val reply = ExchangeCompleteReply()
       Future.successful(reply)
     }
 

--- a/src/it/scala/dummyWorker.scala
+++ b/src/it/scala/dummyWorker.scala
@@ -1,0 +1,163 @@
+package it.rpc.master.client
+
+import io.grpc.{Channel, StatusRuntimeException, ManagedChannelBuilder, ManagedChannel}
+import java.util.logging.{Level, Logger};
+import java.util.concurrent.TimeUnit;
+import scala.util.Random
+
+import com.google.protobuf.ByteString
+import protos.distsortMaster.{
+  DistsortMasterGrpc, 
+  ReadyRequest,
+  ReadyReply,
+  KeyRangeRequest,
+  KeyRangeReply,
+  PartitionCompleteRequest,
+  PartitionCompleteReply,
+  ExchangeCompleteRequest,
+  ExchangeCompleteReply,
+  SortFinishRequest,
+  SortFinishReply
+}
+
+class DummyWorker (workerName: String, port: Int, masterHostname: String, masterPort: Int) {
+  private val logger = Logger.getLogger(classOf[DummyWorker].getName)
+  val channel = ManagedChannelBuilder.forAddress(masterHostname, masterPort).usePlaintext().build
+  val blockingStub = DistsortMasterGrpc.blockingStub(channel)
+
+  def run(): Unit = {
+    val syncPointOne = sendReadySignal(workerName, "DummyIpAddress")
+    assert(syncPointOne)
+    logger.info("Sync Point 1 passed\n")
+
+    // Do sampling
+    val numSamples = 5
+    var randomSample = Array.fill[Byte](10 * numSamples)(0)
+    Random.nextBytes(randomSample)
+    val samples: List[ByteString] =
+      for (i <- (0 until numSamples).toList) yield ByteString.copyFrom(randomSample.drop(i * 10).take(10))
+    assert(samples.length == numSamples)
+    // Done sampling
+    val (keyList, workerIpList) = sendKeyRange(workerName, samples.length, samples)
+    assert(keyList != List.empty)
+    assert(workerIpList != List.empty)
+    val keyListInString = keyList.map(_.toByteArray.map(_.toChar).mkString)
+    logger.info("Sync Point 2 passed\n")
+
+    // Do sorting
+    // ...
+    // Done sorting
+    val syncPointThree = sendPartitionCompleteSignal(workerName)
+    assert(syncPointThree)
+    logger.info("Sync Point 3 passed\n")
+
+    // Do partition exchange
+    // ...
+    // Done partition exchange
+    val syncPointFour = sendExchangeCompleteSignal(workerName)
+    assert(syncPointFour)
+    logger.info("Sync Point 4 passed\n")
+
+    // Do local partition merge
+    // ...
+    // Done local partition merge
+    val syncPointFive = sendFinishSignal(workerName)
+    assert(syncPointFive)
+    logger.info("Sync Point 5 passed\n")
+
+    logger.info(s"$workerName finished!")
+    shutdown()
+  }
+
+
+  def shutdown(): Unit = {
+    channel.shutdown.awaitTermination(5, TimeUnit.SECONDS)
+  }
+
+  def sendReadySignal(workerName: String, workerIpAddress: String): Boolean = {
+    logger.info(workerName + " is ready")
+    val request = ReadyRequest(workerName = workerName, workerIpAddress = workerIpAddress)
+
+    try {
+      val response = blockingStub.workerReady(request)
+      logger.info(" >> Master: All workers are ready!")
+    }
+    catch {
+      case e: StatusRuntimeException =>
+        logger.info("RPC failed in client ready")
+        return false
+    }
+
+    return true
+  }
+
+  def sendKeyRange(workerName: String, numSamples: Int, samples: List[ByteString]): (List[ByteString], List[String]) = {
+    logger.info(workerName + " sending key range")
+    val request = KeyRangeRequest( 
+      numSamples = numSamples,
+      samples = samples
+    )
+
+    try {
+      val response = blockingStub.keyRange(request)
+      logger.info(" >> Master: Sent key range to workers!")
+      return (response.keyList.toList, response.workerIpList.toList)
+    } catch {
+      case e: StatusRuntimeException =>
+        logger.info("RPC failed in client keyRange")
+    }
+
+    return (List(), List())
+  }
+
+  def sendPartitionCompleteSignal(workerName: String): Boolean = {
+    logger.info(s"$workerName finished partitioning")
+    val request = PartitionCompleteRequest()
+
+    try {
+      val response = blockingStub.partitionComplete(request)
+      logger.info(" >> Master: All workers have completed partitioning!")
+    }
+    catch {
+      case e: StatusRuntimeException =>
+        logger.info("RPC failed in client partitionComplete")
+        return false
+    }
+
+    return true
+  }
+
+  def sendExchangeCompleteSignal(workerName: String): Boolean = {
+    logger.info(s"$workerName partition exchange complete")
+    val request = ExchangeCompleteRequest()
+
+    try {
+      val response = blockingStub.exchangeComplete(request)
+      logger.info(" >> Master: All workers have completed partition exchange!")
+    }
+    catch {
+      case e: StatusRuntimeException =>
+        logger.info("RPC failed in client exchangeComplete")
+        return false
+    }
+
+    return true
+  }
+
+  def sendFinishSignal(workerName: String): Boolean ={
+    logger.info(workerName + " sending finish signal")
+    val request = SortFinishRequest()
+
+    try {
+      val response = blockingStub.sortFinish(request)
+      logger.info(" >> Master: All workers finished sorting!")
+    }
+    catch {
+      case e: StatusRuntimeException =>
+        logger.info("RPC failed in client sort finish")
+        return false
+    }
+
+    return true
+  }
+}

--- a/src/it/scala/dummyWorker.scala
+++ b/src/it/scala/dummyWorker.scala
@@ -20,7 +20,7 @@ import protos.distsortMaster.{
   SortFinishReply
 }
 
-class DummyWorker (workerName: String, port: Int, masterHostname: String, masterPort: Int) {
+class DummyWorker (workerName: String, masterHostname: String, masterPort: Int) {
   private val logger = Logger.getLogger(classOf[DummyWorker].getName)
   val channel = ManagedChannelBuilder.forAddress(masterHostname, masterPort).usePlaintext().build
   val blockingStub = DistsortMasterGrpc.blockingStub(channel)

--- a/src/it/scala/masterRpcTest.scala
+++ b/src/it/scala/masterRpcTest.scala
@@ -1,7 +1,29 @@
 import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.{Future, ExecutionContext, Await}
+import scala.concurrent.duration._
+import common.FutureExt.FutureCompanionOps
+import master.Entrypoint.{main => masterMain}
+import it.rpc.master.client.DummyWorker
 
 class MasterRpcTest extends AnyFunSuite {
+  implicit private val ec = ExecutionContext.global
+
   test("dummy integration test") {
     println("dummy integration test success")
+  }
+
+  test("single master single worker") {
+    val masterPort = 34632
+    val workerPort = 32871
+    val numWorkers = 1
+    val masterTask = Future {
+      masterMain(Array(numWorkers.toString, masterPort.toString))
+    }
+    val workerTask = Future {
+      val worker = new DummyWorker("worker-1", workerPort, "127.0.0.1", masterPort)
+      worker.run()
+    }
+    val tasks = List(masterTask, workerTask)
+    Await.result(Future.all(tasks), 10 seconds)
   }
 }

--- a/src/it/scala/masterRpcTest.scala
+++ b/src/it/scala/masterRpcTest.scala
@@ -13,17 +13,30 @@ class MasterRpcTest extends AnyFunSuite {
   }
 
   test("single master single worker") {
-    val masterPort = 34632
-    val workerPort = 32871
+    val masterPort = 10000
     val numWorkers = 1
     val masterTask = Future {
       masterMain(Array(numWorkers.toString, masterPort.toString))
     }
     val workerTask = Future {
-      val worker = new DummyWorker("worker-1", workerPort, "127.0.0.1", masterPort)
+      val worker = new DummyWorker("worker-0", "127.0.0.1", masterPort)
       worker.run()
     }
     val tasks = List(masterTask, workerTask)
+    Await.result(Future.all(tasks), 10 seconds)
+  }
+
+  test("single master multiple worker - 1") {
+    val masterPort = 10001
+    val numWorkers = 3
+    val masterTask = Future {
+      masterMain(Array(numWorkers.toString, masterPort.toString))
+    }
+    val workerTasks = for (i <- (0 until numWorkers).toList) yield Future {
+      val worker = new DummyWorker(s"worker-$i", "127.0.0.1", masterPort)
+      worker.run()
+    }
+    val tasks = List(masterTask) ++ workerTasks
     Await.result(Future.all(tasks), 10 seconds)
   }
 }


### PR DESCRIPTION
**Note: Huge PR**

- Re-designed network.DistSortServer to be an abstract class.
- Implement divideKeyRange and control flow of master.
- Implement unit tests on some datatypes for syncing.
- Implement overall test for master in `src/it/scala/masterRpcTest.scala`.
- Minor changes on master.DistSortServerImpl, which extends network.DistSortServer.
- Minor fixes (format, comments, errors, etc.)